### PR TITLE
Add deploy workflow for GCP VM

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,66 @@
+name: Deploy to GCP VM
+
+on:
+  push:
+    branches: [main]
+    paths-ignore: ['*.md', 'docs/**', 'LICENSE', '.gitignore']
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-pinnacle-pin-bot
+  cancel-in-progress: false
+
+jobs:
+  ci:
+    uses: LibruaryNFT/shared-workflows/.github/workflows/node-ci.yml@main
+    with:
+      node-version: '20'
+      test-command: "echo 'No tests yet — CI validates install'"
+
+  deploy:
+    needs: ci
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Deploy via SSH
+        env:
+          SSH_KEY: ${{ secrets.GCP_VM_SSH_KEY }}
+          VM_HOST: ${{ secrets.GCP_VM_HOST }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$VM_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+
+          ssh -o StrictHostKeyChecking=accept-new "deploy@${VM_HOST}" << 'DEPLOY'
+            set -e
+            cd ~/pinnacle-pin-bot
+            echo "==> Pulling latest..."
+            git pull origin main
+            echo "==> Installing dependencies..."
+            npm install --production
+            echo "==> Restarting service..."
+            sudo systemctl restart pinnacle-pin-bot
+            echo "==> Checking service status..."
+            sleep 3
+            sudo systemctl is-active pinnacle-pin-bot
+            echo "==> Deploy complete"
+          DEPLOY
+
+      - name: Verify service is running
+        env:
+          SSH_KEY: ${{ secrets.GCP_VM_SSH_KEY }}
+          VM_HOST: ${{ secrets.GCP_VM_HOST }}
+        run: |
+          ssh -o StrictHostKeyChecking=accept-new "deploy@${VM_HOST}" \
+            "sudo journalctl -u pinnacle-pin-bot --no-pager -n 10"
+
+  notify:
+    needs: [ci, deploy]
+    if: failure()
+    uses: LibruaryNFT/shared-workflows/.github/workflows/notify-failure.yml@main
+    with:
+      project: 'pinnacle-pin-bot'
+    secrets:
+      CC_PAT: ${{ secrets.CC_PAT }}
+      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}


### PR DESCRIPTION
## Summary
- Adds `deploy.yml` GitHub Actions workflow for automated deployment to the shared GCP VM
- Triggers on push to `main` (ignoring docs-only changes) and manual `workflow_dispatch`
- Runs CI first (shared node-ci workflow), then SSHs to the VM to pull, install, restart, and verify
- Failure notifications via shared notify-failure workflow (creates issue in command-center + Discord)

## Secrets Required
Before merging, these secrets must be configured in the repo (Settings > Secrets > Actions):

| Secret | Description |
|--------|-------------|
| `GCP_VM_SSH_KEY` | SSH private key (ed25519) authorized on the GCP VM for the `deploy` user |
| `GCP_VM_HOST` | GCP VM external IP address |

The `deploy` user needs sudo access to `systemctl restart pinnacle-pin-bot` on the VM.

**Note:** Both `pinnacle-pin-bot` and `flow-event-listener` share the same GCP VM, so the same SSH key and host secrets work for both repos.

## Test plan
- [ ] Add `GCP_VM_SSH_KEY` and `GCP_VM_HOST` secrets to repo
- [ ] Create `deploy` user on GCP VM with limited sudo (systemctl restart only)
- [ ] Trigger workflow manually via `workflow_dispatch` and verify deployment succeeds
- [ ] Verify service is running after deploy (`systemctl is-active pinnacle-pin-bot`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)