### PR TITLE
Add Hetzner VPS deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,63 @@
+name: Deploy to Hetzner VPS
+
+on:
+  push:
+    branches: [main, master]
+    paths-ignore: ['*.md', 'docs/**', 'LICENSE', '.gitignore']
+  workflow_dispatch:
+
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+
+jobs:
+  test:
+    uses: LibruaryNFT/shared-workflows/.github/workflows/node-ci.yml@main
+    with:
+      test-command: "echo 'No tests yet — CI validates install'"
+
+  deploy:
+    name: Deploy to VPS
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.VAULTOPOLIS_VPS_SSH_KEY }}" | base64 -d > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H ${{ secrets.VAULTOPOLIS_VPS_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Deploy
+        run: |
+          ssh -i ~/.ssh/deploy_key root@${{ secrets.VAULTOPOLIS_VPS_HOST }} '
+            cd /opt/pinnacle-pin-bot &&
+            git pull origin main &&
+            chown -R nodeservices:nodeservices /opt/pinnacle-pin-bot &&
+            npm install --production &&
+            chown -R nodeservices:nodeservices /opt/pinnacle-pin-bot &&
+            systemctl restart pinnacle-pin-bot
+          '
+
+      - name: Health check
+        run: |
+          sleep 10
+          ssh -i ~/.ssh/deploy_key root@${{ secrets.VAULTOPOLIS_VPS_HOST }} \
+            'curl -sf http://localhost:8092/health | python3 -m json.tool'
+
+      - name: Cleanup SSH key
+        if: always()
+        run: rm -f ~/.ssh/deploy_key
+
+  notify:
+    needs: [test, deploy]
+    if: failure()
+    uses: LibruaryNFT/shared-workflows/.github/workflows/notify-failure.yml@main
+    with:
+      project: 'pinnacle-pin-bot'
+    secrets:
+      CC_PAT: ${{ secrets.CC_PAT }}
+      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}


### PR DESCRIPTION
## Summary
- Adds automated deploy workflow for the Vaultopolis Hetzner VPS (46.225.59.82)
- Pipeline: shared `node-ci` validation -> SSH deploy (git pull + npm install + systemctl restart) -> health check on `:8092/health`
- Uses `VAULTOPOLIS_VPS_SSH_KEY` and `VAULTOPOLIS_VPS_HOST` repo secrets (need to be configured)
- Failure notifications via shared `notify-failure` workflow (Discord + command-center issue)

## Secrets required before merging
- `VAULTOPOLIS_VPS_SSH_KEY` — base64-encoded SSH private key for root@46.225.59.82
- `VAULTOPOLIS_VPS_HOST` — `46.225.59.82`

## Test plan
- [ ] Add `VAULTOPOLIS_VPS_SSH_KEY` and `VAULTOPOLIS_VPS_HOST` secrets to repo settings
- [ ] Trigger workflow via `workflow_dispatch` to validate SSH + deploy
- [ ] Verify health check passes after deploy
- [ ] Test failure notification by temporarily breaking the health check

🤖 Generated with [Claude Code](https://claude.com/claude-code)