### PR TITLE
chore: remove unused mongodb and node-cron deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,6 @@
     "axios": "^1.9.0",
     "dotenv": "^17.3.1",
     "fcl-subscribe": "^0.1.9",
-    "mongodb": "^6.15.0",
-    "node-cron": "^4.2.1",
     "node-fetch": "^2.7.0",
     "pino": "^10.3.1",
     "twitter-api-v2": "^1.22.0"


### PR DESCRIPTION
## Summary

- Remove `mongodb` from dependencies — never imported or used in any source file
- Remove `node-cron` from dependencies — never imported or used in any source file

Both packages were identified as dead dependencies through a full codebase search. Removing them reduces install size and eliminates unnecessary attack surface.

No code changes needed since neither package is referenced anywhere.

## Test plan

- [ ] Verify `npm install` completes without errors
- [ ] Verify `npm start` runs the bot normally (no missing module errors)