### PR TITLE
feat(deploy): version pinnacle-pin-bot.service + replace sed-hack with cp

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
             chown -R nodeservices:nodeservices /opt/pinnacle-pin-bot &&
             npm install --production &&
             chown -R nodeservices:nodeservices /opt/pinnacle-pin-bot &&
-            sed -i "s|ExecStart=.*|ExecStart=/usr/bin/node /opt/pinnacle-pin-bot/start.js --live-tweets|" /etc/systemd/system/pinnacle-pin-bot.service &&
+            cp /opt/pinnacle-pin-bot/deploy/pinnacle-pin-bot.service /etc/systemd/system/pinnacle-pin-bot.service &&
             systemctl daemon-reload &&
             systemctl restart pinnacle-pin-bot
           '

--- a/deploy/pinnacle-pin-bot.service
+++ b/deploy/pinnacle-pin-bot.service
@@ -1,0 +1,37 @@
+[Unit]
+OnFailure=discord-notify@%n.service
+Description=Pinnacle Pin Bot — Disney Pinnacle NFT sales Twitter bot
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=nodeservices
+Group=nodeservices
+WorkingDirectory=/opt/pinnacle-pin-bot
+EnvironmentFile=/etc/gcp/env
+Environment=FLOW_ACCESS_NODE=https://mainnet.onflow.org
+Environment=FLOW_REST_ENDPOINT=https://rest-mainnet.onflow.org
+Environment=CHECK_INTERVAL_SECONDS=60
+Environment=HEALTH_PORT=8092
+Environment=NODE_ENV=production
+ExecStart=/usr/bin/node /opt/pinnacle-pin-bot/start.js --live-tweets
+Restart=on-failure
+RestartSec=30
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=pinnacle-pin-bot
+
+# Security hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/opt/pinnacle-pin-bot
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Closes a drift finding from the post-storm fleet-wide audit (see eco [post-mortem](https://github.com/LibruaryNFT/eco/blob/master/intel/incidents/post-mortem-2026-05-23-ntfy-storm-drift-cascade.md)): the unit file lived only on VPS1, hand-managed since provisioning.

## Changes

1. **`deploy/pinnacle-pin-bot.service`** — verbatim capture from VPS1.
2. **`.github/workflows/deploy.yml`** — replaces:
   ```bash
   sed -i "s|ExecStart=.*|ExecStart=/usr/bin/node /opt/pinnacle-pin-bot/start.js --live-tweets|" /etc/systemd/system/pinnacle-pin-bot.service
   ```
   with:
   ```bash
   cp /opt/pinnacle-pin-bot/deploy/pinnacle-pin-bot.service /etc/systemd/system/pinnacle-pin-bot.service
   ```
   The `sed` hack was needed because the unit file wasn't versioned — every deploy rewrote ExecStart in-place. Now we cp the versioned source-of-truth directly. Same end state, idempotent.

## Note

The unit currently has `OnFailure=discord-notify@%n.service` — the "discord-notify" name is **legacy** (the script behind it routes through ntfy now). VPS1's `/usr/local/bin/discord-notify.sh` still has the direct `curl https://ntfy.sh/...` pattern without Resend fallback — same class of bug we closed on VPS2 in [devalpha#90](https://github.com/LibruaryNFT/devalpha/pull/90). VPS1 alert-helper migration deferred to keep this PR self-contained.

## Test plan

- [x] Verbatim capture verified zero-diff after CRLF normalization
- [x] yaml parses
- [ ] Post-merge: deploy completes; `cat /etc/systemd/system/pinnacle-pin-bot.service` matches repo; health check still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)