### PR TITLE
fix(health): stop reporting degraded when idle (false Kuma DOWN page)

### DIFF
--- a/__tests__/helpers.test.js
+++ b/__tests__/helpers.test.js
@@ -5,7 +5,46 @@ import {
   unwrapAddressField,
   formatPrice,
   composeTweet,
+  computeHealthStatus,
 } from "../lib/helpers.js";
+
+describe("computeHealthStatus", () => {
+  it("idle bot (no qualifying sale, no tweet) is HEALTHY, not degraded", () => {
+    // Regression 2026-06-08: the old silentTooLong heuristic flagged this as
+    // degraded after 1h uptime -> Kuma "DOWN" -> false ntfy page.
+    expect(computeHealthStatus({ lastSaleAttemptedAt: null, lastTweetAt: null })).toBe("healthy");
+  });
+
+  it("qualifying sale recorded but never tweeted is DEGRADED (real fault)", () => {
+    expect(computeHealthStatus({ lastSaleAttemptedAt: "2026-06-08T17:00:00Z", lastTweetAt: null })).toBe(
+      "degraded",
+    );
+  });
+
+  it("sale tweeted (tweet newer than sale) is HEALTHY", () => {
+    expect(
+      computeHealthStatus({
+        lastSaleAttemptedAt: "2026-06-08T17:00:00Z",
+        lastTweetAt: "2026-06-08T17:00:05Z",
+      }),
+    ).toBe("healthy");
+  });
+
+  it("newer sale than last tweet is DEGRADED (latest qualifying sale untweeted)", () => {
+    expect(
+      computeHealthStatus({
+        lastSaleAttemptedAt: "2026-06-08T18:00:00Z",
+        lastTweetAt: "2026-06-08T17:00:00Z",
+      }),
+    ).toBe("degraded");
+  });
+
+  it("has tweeted before, no new sale pending is HEALTHY", () => {
+    expect(
+      computeHealthStatus({ lastSaleAttemptedAt: null, lastTweetAt: "2026-06-08T17:00:00Z" }),
+    ).toBe("healthy");
+  });
+});
 
 describe("extract", () => {
   it("returns primitives as-is", () => {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -99,10 +99,38 @@ function composeTweet({ usd, chars, ed }) {
   return `$${formatPrice(usd)} — ${chars} just sold on @DisneyPinnacle\nhttps://disneypinnacle.com/pin/${ed.id}`;
 }
 
+/**
+ * Computes the /health status word.
+ *
+ * "degraded" must mean an ACTIONABLE problem, not normal idle. This bot only
+ * tweets on sales >= the price threshold, which legitimately go hours/days
+ * between occurrences — so "no tweet recently" is NOT a problem. The only
+ * health-endpoint signal of a real fault is `saleWithoutTweet`: a qualifying
+ * sale was recorded (lastSaleAttemptedAt) but never produced a tweet, meaning
+ * the tweet pipeline broke.
+ *
+ * Process/subscription liveness is covered elsewhere (systemd, the Kuma HTTP
+ * check, eco's pinnacle-bot-watch) — NOT by the old uptime-based
+ * `silentTooLong` heuristic, which paged on normal idle (a >1h-uptime bot with
+ * no qualifying sale was flagged degraded -> Kuma "DOWN" -> ntfy). Removed
+ * 2026-06-08.
+ *
+ * @param {{lastSaleAttemptedAt: string|null, lastTweetAt: string|null}} state
+ * @returns {"healthy"|"degraded"}
+ */
+function computeHealthStatus({ lastSaleAttemptedAt, lastTweetAt }) {
+  const saleWithoutTweet =
+    lastSaleAttemptedAt !== null &&
+    (lastTweetAt === null ||
+      new Date(lastSaleAttemptedAt).getTime() > new Date(lastTweetAt).getTime());
+  return saleWithoutTweet ? "degraded" : "healthy";
+}
+
 module.exports = {
   extract,
   decodeEventPayloadBase64,
   unwrapAddressField,
   formatPrice,
   composeTweet,
+  computeHealthStatus,
 };

--- a/monitor.js
+++ b/monitor.js
@@ -9,6 +9,7 @@ const { TwitterApi } = require("twitter-api-v2");
 const { subscribeToEvents } = require("fcl-subscribe");
 const logger = require("./logger");
 const { renderSaleCard } = require("./render-card");
+const { computeHealthStatus } = require("./lib/helpers");
 
 /* ── File Logging Setup ─────────────────────────────────── */
 // Create log file with timestamp
@@ -916,14 +917,8 @@ const botStartTime = Date.now();
 http
   .createServer((req, res) => {
     if (req.url === "/health" && (req.method === "GET" || req.method === "HEAD")) {
-      const saleWithoutTweet =
-        lastSaleAttemptedAt !== null &&
-        (lastTweetAt === null ||
-          new Date(lastSaleAttemptedAt).getTime() > new Date(lastTweetAt).getTime());
-      const uptimeSeconds = Math.floor((Date.now() - botStartTime) / 1000);
-      const silentTooLong = config.ENABLE_TWEETS && lastTweetAt === null && uptimeSeconds > 3600;
       const body = JSON.stringify({
-        status: saleWithoutTweet || silentTooLong ? "degraded" : "healthy",
+        status: computeHealthStatus({ lastSaleAttemptedAt, lastTweetAt }),
         service: "pinnacle-pin-bot",
         uptime: Math.floor((Date.now() - botStartTime) / 1000),
         mode: config.IS_BACKFILL ? "backfill" : "live",


### PR DESCRIPTION
## What

`/health` returned `status: degraded` whenever the bot had been up >1h with no tweet (the `silentTooLong` heuristic). But this is a **threshold-gated** bot — it only tweets on sales ≥ `PINNACLE_PRICE_THRESHOLD`, which legitimately go hours/days apart. So **normal idle was flagged degraded**, which fails Kuma's `healthy` keyword → `vault: pinnacle DOWN` → ntfy page (fired 2026-06-08 10:09).

Verified live: the bot is `active` and polling (`Price N below threshold 150, skipping`) — nothing wrong, just no qualifying sale.

## Fix

- Extract `computeHealthStatus()` into `lib/helpers.js` (pure + testable, matching the repo's helper pattern).
- Drop `silentTooLong`. `degraded` now means only an **actionable** fault: `saleWithoutTweet` (a qualifying sale was recorded but never tweeted = tweet pipeline broke).
- Process/subscription liveness stays covered by systemd + the Kuma HTTP check + eco's `pinnacle-bot-watch`.
- 5 regression tests.

## Test

```
$ node -e '...computeHealthStatus cases...'
PASS idle(null,null) -> healthy
PASS sale,no-tweet   -> degraded
PASS sale<tweet      -> healthy
PASS sale>tweet      -> degraded
PASS tweet,no-sale   -> healthy
ALL PASS
$ node --check monitor.js  # parses OK
```

After merge+deploy, the live `/health` will report `healthy` while idle → Kuma `vault: pinnacle` goes green and stops paging.