### PR TITLE
feat: expose + verify deployed sha in /health

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,11 +54,19 @@ jobs:
             systemctl restart pinnacle-pin-bot
           '
 
-      - name: Health check
+      - name: Health check (status + SHA match)
+        env:
+          SHA: ${{ github.sha }}
         run: |
           sleep 10
-          ssh -p 2222 -i ~/.ssh/deploy_key root@${{ secrets.VAULTOPOLIS_VPS_HOST }} \
-            'curl -sf http://localhost:8092/health | python3 -m json.tool'
+          BODY=$(ssh -p 2222 -i ~/.ssh/deploy_key root@${{ secrets.VAULTOPOLIS_VPS_HOST }} \
+            'curl -sf http://localhost:8092/health')
+          echo "$BODY" | python3 -m json.tool
+          GOT_SHA=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('sha',''))")
+          if [ "$GOT_SHA" != "$SHA" ]; then
+            echo "::error::running SHA ($GOT_SHA) != shipped $SHA — restart did not pick up new code"; exit 1
+          fi
+          echo "Verified: running SHA matches $SHA"
 
       - name: Cleanup SSH key
         if: always()

--- a/monitor.js
+++ b/monitor.js
@@ -914,6 +914,20 @@ async function runLiveSubscription() {
 const HEALTH_PORT = Number(process.env.HEALTH_PORT || 8090);
 const botStartTime = Date.now();
 
+// Commit this process booted with, read ONCE at start. /health exposes it so
+// the deploy verifier + ops audit can prove source==deployed==running and
+// catch "deployed but never restarted".
+const GIT_SHA = (() => {
+  try {
+    return require("child_process")
+      .execSync("git rev-parse HEAD", { cwd: __dirname, timeout: 2000 })
+      .toString()
+      .trim();
+  } catch {
+    return "unknown";
+  }
+})();
+
 http
   .createServer((req, res) => {
     if (req.url === "/health" && (req.method === "GET" || req.method === "HEAD")) {
@@ -927,6 +941,7 @@ http
         tweetsSent,
         lastTweetAt,
         lastSaleAttemptedAt,
+        sha: GIT_SHA,
         timestamp: new Date().toISOString(),
       });
       res.writeHead(200, { "Content-Type": "application/json" });


### PR DESCRIPTION
pinnacle-pin-bot's deploy already pulled origin/main + restarted, but the health check was a bare `curl -sf` (200 only). Add SHA accountability:

- `/health` now returns `sha` (`GIT_SHA` read once at process start via `git rev-parse HEAD`).
- Deploy's health-check step now asserts the running sha == shipped commit (catches 'deployed but never restarted').

## Prod verification
N/A pre-merge (deploy-on-merge to main). `https://...:8092/health` already returns 200 with the bot's status; `sha` will appear after the next deploy and the verify step will gate it.